### PR TITLE
Kenson/navbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,9 @@ const router = createBrowserRouter([
     Component: Layout,
     children: [
       { path: "/", Component: Home },
-      { path: "/about", Component: About },
+      // { path: "/about", Component: About },
+      // { path: "/contact", Component: Contact },
+
       // A data route is a route that has a data loader function
       // that will be called when the route is rendered.
       // Although the data loader function is async, it is not

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Layout } from "./Layout";
 
 // Bring in the pages
 import { Home } from "./pages/Home";
-import { About } from "./pages/About";
+// import { About } from "./pages/About";
 // import { DataRoute } from "./pages/DataRoute";
 import { NoMatch } from "./pages/NoMatch";
 

--- a/src/partials/Header/Header.tsx
+++ b/src/partials/Header/Header.tsx
@@ -27,14 +27,14 @@ export function Header() {
           <nav className="hidden md:flex md:grow">
             {/* Desktop menu links */}
             <ul className="flex grow flex-wrap items-center justify-end">
-              <li>
+              {/* <li>
                 <Link
                   to="about"
                   className="flex items-center px-4 py-2 text-gray-300 transition duration-150 ease-in-out hover:text-gray-200"
                 >
                   About
                 </Link>
-              </li>
+              </li> */}
               {/* <li>
                 <Link
                   to="/data-route"
@@ -43,15 +43,14 @@ export function Header() {
                   Data Route
                 </Link>
               </li> */}
-              <li>
+              {/* <li>
                 <Link
                   to="/contact"
                   className="flex items-center px-4 py-2 text-gray-300 transition duration-150 ease-in-out hover:text-gray-200"
                 >
                   Contact
                 </Link>
-              </li>
-              {/* 1st level: hover */}
+              </li> */}
             </ul>
           </nav>
 


### PR DESCRIPTION
# Removes link from navbar

The About and Contact links have been commented out, while the content for those pages are discussed. 

## Dependencies added

None

## Usage

No change